### PR TITLE
Dev/array iterators

### DIFF
--- a/qpm.json
+++ b/qpm.json
@@ -7,6 +7,7 @@
     "version": "5.0.0",
     "url": "https://github.com/QuestPackageManager/beatsaber-hook",
     "additionalData": {
+      "cmake": true,
       "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/libbeatsaber-hook.so",
       "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/debug_libbeatsaber-hook.so",
       "branchName": "master"

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -11,7 +11,8 @@
       "additionalData": {
         "soLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/libbeatsaber-hook.so",
         "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/debug_libbeatsaber-hook.so",
-        "branchName": "master"
+        "branchName": "master",
+        "cmake": true
       }
     },
     "workspace": {

--- a/shared/utils/typedefs-array.hpp
+++ b/shared/utils/typedefs-array.hpp
@@ -411,10 +411,13 @@ struct ArrayW {
                 *value = static_cast<T>(v);
             }
 
+// only if wbarrier is available use it for compiling a wbarrier assign. Since unity2021 this seems to not be available in beat saber, excercise caution for other games!
+#ifdef IL2CPP_WBARRIER_AVAILABLE
             // writes on ref types should happen with wbarrier
             if constexpr (il2cpp_utils::il2cpp_reference_type<T>) {
                 il2cpp_functions::GarbageCollector_SetWriteBarrier(reinterpret_cast<void**>(value));
             }
+#endif
 
             return *value;
         }

--- a/shared/utils/typedefs-array.hpp
+++ b/shared/utils/typedefs-array.hpp
@@ -402,7 +402,7 @@ struct ArrayW {
 
         /// @brief assignment operator for assigning into an array directly via arr[idx] = value;
         template<typename U>
-        requires(std::is_convertible_v<U, T> || std::is_same_v<T, std::decay_t<U>> && !const_array)
+        requires((std::is_convertible_v<U, T> || std::is_same_v<T, std::decay_t<U>>) && !const_array)
         T& operator=(U&& v) {
             // if this is already the same type, no need to static_cast
             if constexpr (std::is_same_v<T, std::decay_t<U>>) {


### PR DESCRIPTION
 - Make array iterators and values just wrap a `T*`
 - Remove Wbarrier if a compile time definition is not defined, since if it's not in the game there's no point in doing that
 - operator= for ArrayValue will now actually assign the underlying value, while the ctors ArrayValue(ArrayValue)  will function as actual copy/move ctors