### PR TITLE
il2cpp_async & internals rework for il2cpp_aware_thread

### DIFF
--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -701,6 +701,9 @@ namespace il2cpp_utils {
         static inline bool is_thread_attached() {
             il2cpp_functions::Init();
             auto currentThread = il2cpp_functions::thread_current();
+            // if there is no current thread might as well just return false since we didn't get a thread
+            if (!currentThread) return false;
+
             size_t threadCount = 0;
             auto threads_begin = il2cpp_functions::thread_get_all_attached_threads(&threadCount);
             auto threads_end = threads_begin + threadCount;

--- a/shared/utils/il2cpp-utils.hpp
+++ b/shared/utils/il2cpp-utils.hpp
@@ -2,6 +2,7 @@
 #define IL2CPP_UTILS_H
 
 #include <sys/types.h>
+#include <exception>
 #include <forward_list>
 #include <utility>
 #pragma pack(push)
@@ -684,86 +685,124 @@ namespace il2cpp_utils {
         return out;
     }
 
+    namespace threading {
+        static inline thread_local JNIEnv* env;
+        static inline JNIEnv* get_current_env() {
+            return env;
+        }
+
+        static inline std::string current_thread_id() {
+            std::stringstream id; id << std::this_thread::get_id();
+            return id.str();
+        }
+
+        /// @brief gets whether the current thread is attached to il2cpp
+        /// @return true for attached, false for not attached
+        static inline bool is_thread_attached() {
+            il2cpp_functions::Init();
+            auto currentThread = il2cpp_functions::thread_current();
+            size_t threadCount = 0;
+            auto threads_begin = il2cpp_functions::thread_get_all_attached_threads(&threadCount);
+            auto threads_end = threads_begin + threadCount;
+
+            return std::find(threads_begin, threads_end, currentThread) != threads_end;
+        }
+
+        static inline Il2CppThread* attach_thread() {
+            static auto logger = il2cpp_utils::getLogger().WithContext("attach_thread");
+            logger.info("Attaching thread %s", current_thread_id().c_str());
+            il2cpp_functions::Init();
+            // il2cpp attach
+            auto domain = il2cpp_functions::domain_get();
+            auto thread = il2cpp_functions::thread_attach(domain);
+
+            // jvm attach
+            modloader_jvm->AttachCurrentThread(&env, nullptr);
+            return thread;
+        }
+
+        static inline void detach_thread(Il2CppThread* thread) {
+            static auto logger = il2cpp_utils::getLogger().WithContext("detach_thread");
+            logger.info("Detaching thread %s", current_thread_id().c_str());
+
+            // il2cpp detach
+            il2cpp_functions::Init();
+            il2cpp_functions::thread_detach(thread);
+            // jvm detach
+            modloader_jvm->DetachCurrentThread();
+            env = nullptr;
+        }
+
+        template<typename Func, typename... TArgs>
+        requires(std::is_invocable_v<Func, TArgs...>)
+        static inline std::invoke_result_t<Func, TArgs...> il2cpp_catch_invoke(Func&& func, TArgs&&... args) {
+            static auto logger = getLogger().WithContext("il2cpp_catch_invoke");
+            auto thread_id = current_thread_id();
+            try {
+                logger.error("Invoking function in thread id %s", thread_id.c_str());
+                return std::invoke(std::forward<Func>(func), std::forward<TArgs>(args)...);
+            } catch (RunMethodException const& e) {
+                logger.error("Exception in thread with thread id %s", thread_id.c_str());
+                logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught RunMethodException! what(): %s", e.what());
+                e.log_backtrace();
+                SAFE_ABORT();
+            } catch (exceptions::StackTraceException const& e) {
+                logger.error("Exception in thread with thread id %s", thread_id.c_str());
+                logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught StackTraceException! what(): %s", e.what());
+                SAFE_ABORT();
+            } catch (std::exception const& e) {
+                logger.error("Exception in thread with thread id %s", thread_id.c_str());
+                logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught C++ exception! type name: %s, what(): %s", typeid(e).name(), e.what());
+                SAFE_ABORT();
+            } catch(...) {
+                logger.error("Exception in thread with thread id %s", thread_id.c_str());
+                logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught, unknown exception (not std::exception) with no known what() method!");
+                SAFE_ABORT();
+            }
+        }
+
+        /// @brief helper type to run operator () on something once this variable goes out of scope
+        template<typename F>
+        requires(std::is_invocable_v<F>)
+        struct OnScopeExit {
+            inline OnScopeExit(F f) : f(f) {}
+            inline ~OnScopeExit() {
+                f();
+            }
+            F f;
+        };
+
+        template<typename Func, typename... TArgs>
+        requires(std::is_invocable_v<Func, TArgs...>)
+        static inline std::invoke_result_t<Func, TArgs...> il2cpp_attached_thread(Func&& func, TArgs&&... args) {
+            auto thread = attach_thread();
+            // helper to detach thread on out of scope
+            OnScopeExit onScopeExit(std::bind(&detach_thread, thread));
+
+            return il2cpp_catch_invoke(std::forward<Func>(func), std::forward<TArgs>(args)...);
+        }
+
+        template<typename Func, typename... TArgs>
+        requires(std::is_invocable_v<Func, TArgs...>)
+        static inline std::invoke_result_t<Func, TArgs...> il2cpp_async_internal(Func&& func, TArgs&&... args) {
+            if (is_thread_attached()) {
+                return il2cpp_catch_invoke(std::forward<Func>(func), std::forward<TArgs>(args)...);
+            } else {
+                return il2cpp_attached_thread(std::forward<Func>(func), std::forward<TArgs>(args)...);
+            }
+        }
+    }
     struct il2cpp_aware_thread : public std::thread {
-        private:
-            static inline thread_local JNIEnv* env;
-        public:
-            static std::string current_thread_id() {
-                std::stringstream id; id << std::this_thread::get_id();
-                return id.str();
-            }
-
-            static inline JNIEnv* get_current_env() noexcept { return env; }
-
-            /// @brief method executed by the thread created in il2cpp_aware_thread
-            /// @param pred the predicate to use in the thread
-            /// @param args the args used
-            template<typename Predicate, typename... TArgs>
-            requires(std::is_invocable_v<Predicate, std::decay_t<TArgs>...>)
-            static void internal_thread(Predicate&& pred, TArgs&&... args) {
-                auto logger = getLogger().WithContext("internal_thread_" + current_thread_id());
-
-                // attach thread to jvm
-                modloader_jvm->AttachCurrentThread(&env, nullptr);
-
-                il2cpp_functions::Init();
-
-                logger.info("Attaching thread");
-                auto domain = il2cpp_functions::domain_get();
-                auto thread = il2cpp_functions::thread_attach(domain);
-
-                logger.info("Invoking predicate");
-                try {
-                    std::invoke(std::forward<Predicate>(pred), std::forward<std::decay_t<TArgs>>(args)...);
-                } catch(RunMethodException const& e) {
-                    logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught RunMethodException! what(): %s", e.what());
-                    e.log_backtrace();
-                    if (e.ex) e.rethrow();
-                    il2cpp_functions::thread_detach(thread);
-                    modloader_jvm->DetachCurrentThread();
-                    env = nullptr;
-                    SAFE_ABORT();
-                } catch(exceptions::StackTraceException const& e) {
-                    logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught StackTraceException! what(): %s", e.what());
-                    e.log_backtrace();
-                    il2cpp_functions::thread_detach(thread);
-                    modloader_jvm->DetachCurrentThread();
-                    env = nullptr;
-                    SAFE_ABORT();
-                } catch(std::exception& e) {
-                    logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught C++ exception! type name: %s, what(): %s", typeid(e).name(), e.what());
-                    il2cpp_functions::thread_detach(thread);
-                    modloader_jvm->DetachCurrentThread();
-                    env = nullptr;
-                    SAFE_ABORT();
-                } catch(...) {
-                    logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught, unknown C++ exception (not std::exception) with no known what() method!");
-                    il2cpp_functions::thread_detach(thread);
-                    modloader_jvm->DetachCurrentThread();
-                    env = nullptr;
-                    SAFE_ABORT();
-                }
-
-                logger.info("Detaching thread");
-
-                // detach il2cpp thread
-                il2cpp_functions::thread_detach(thread);
-
-                // detach thread from jvm
-                modloader_jvm->DetachCurrentThread();
-                env = nullptr;
-            }
-
             /// @brief creates a thread that automatically will register with il2cpp and deregister once it exits, ensure your args live longer than the thread if they're by reference!
             /// @param pred the predicate to use for the thread
             /// @param args the arguments to pass to the thread (& predicate)
             /// @return created thread, which is the same as you creating a default one
-            template<typename Predicate, typename... TArgs>
-            requires(std::is_invocable_v<Predicate, std::decay_t<TArgs>...>)
-            explicit il2cpp_aware_thread(Predicate&& pred, TArgs&&... args) :
+            template<typename Func, typename... TArgs>
+            requires(std::is_invocable_v<Func, std::decay_t<TArgs>...>)
+            explicit il2cpp_aware_thread(Func&& pred, TArgs&&... args) :
                 std::thread(
-                    &internal_thread<Predicate, std::decay_t<TArgs>...>,
-                    std::forward<Predicate>(pred),
+                    &il2cpp_utils::threading::il2cpp_attached_thread<Func, std::decay_t<TArgs>...>,
+                    std::forward<Func>(pred),
                     std::forward<TArgs>(args)...
                 )
             {}
@@ -777,101 +816,18 @@ namespace il2cpp_utils {
             }
     };
 
-    template<typename Fp, typename... TArgs>
-    inline std::invoke_result_t<Fp, TArgs...> il2cpp_async_internal_attach(Fp&& f, TArgs&&... args) {
-        auto logger = getLogger().WithContext("internal_async_" + il2cpp_aware_thread::current_thread_id());
-
-        JNIEnv* env = nullptr;
-        // attach thread to jvm
-        modloader_jvm->AttachCurrentThread(&env, nullptr);
-
-        il2cpp_functions::Init();
-
-        logger.info("Attaching thread from async");
-        auto domain = il2cpp_functions::domain_get();
-        auto thread = il2cpp_functions::thread_attach(domain);
-
-        logger.info("Invoking function");
-        try {
-            if constexpr (!std::is_same_v<std::invoke_result_t<Fp, TArgs...>, void>) {
-                auto result = std::invoke(std::forward<Fp>(f), std::forward<TArgs>(args)...);
-                logger.info("Detaching thread from async");
-
-                // detach il2cpp thread
-                il2cpp_functions::thread_detach(thread);
-
-                // detach thread from jvm
-                modloader_jvm->DetachCurrentThread();
-                return result;
-            } else {
-                std::invoke(std::forward<Fp>(f), std::forward<TArgs>(args)...);
-
-                // detach il2cpp thread
-                il2cpp_functions::thread_detach(thread);
-
-                // detach thread from jvm
-                modloader_jvm->DetachCurrentThread();
-                return;
-            }
-        } catch(RunMethodException const& e) {
-            logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught RunMethodException! what(): %s", e.what());
-            e.log_backtrace();
-            if (e.ex) e.rethrow();
-            il2cpp_functions::thread_detach(thread);
-            modloader_jvm->DetachCurrentThread();
-            SAFE_ABORT();
-        } catch(exceptions::StackTraceException const& e) {
-            logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught StackTraceException! what(): %s", e.what());
-            e.log_backtrace();
-            il2cpp_functions::thread_detach(thread);
-            modloader_jvm->DetachCurrentThread();
-            SAFE_ABORT();
-        } catch(std::exception& e) {
-            logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught C++ exception! type name: %s, what(): %s", typeid(e).name(), e.what());
-            il2cpp_functions::thread_detach(thread);
-            modloader_jvm->DetachCurrentThread();
-            SAFE_ABORT();
-        } catch(...) {
-            logger.error("Caught in mod id: " _CATCH_HANDLER_ID ": Uncaught, unknown C++ exception (not std::exception) with no known what() method!");
-            il2cpp_functions::thread_detach(thread);
-            modloader_jvm->DetachCurrentThread();
-            SAFE_ABORT();
-        }
+    template<typename Func, typename... TArgs>
+    requires(std::is_invocable_v<Func, TArgs...>)
+    inline std::future<std::invoke_result_t<Func, TArgs...>> il2cpp_async(std::launch policy, Func&& f, TArgs&&... args) {
+        auto func = &il2cpp_utils::threading::il2cpp_async_internal<Func, TArgs...>;
+        return std::async<decltype(func), Func, TArgs...>(policy, std::move(func), std::forward<Func>(f), std::forward<TArgs>(args)...);
     }
 
-    template<typename Fp, typename... TArgs>
-    requires(std::is_invocable_v<Fp, TArgs...>)
-    inline std::invoke_result_t<Fp, TArgs...> il2cpp_async_internal(Fp&& f, TArgs&&... args) {
-        // check whether the current thread is already attached
-        size_t threadCount = 0;
-        auto threads_begin = il2cpp_functions::thread_get_all_attached_threads(&threadCount);
-        auto threads_end = threads_begin + threadCount;
-        auto current_thread = il2cpp_functions::thread_current();
-        bool is_attached = false;
-        for (auto t = threads_begin; t != threads_end; t++) {
-            if (current_thread == *t) {
-                is_attached = true;
-                break;
-            }
-        }
-
-        if (is_attached) { // we're already attached, nothing to attach or detach
-            return std::invoke(std::forward<Fp>(f), std::forward<TArgs>(args)...);
-        } else { // we are not attached, this means this is a new thread and we should attach ourselves
-            return il2cpp_async_internal_attach<Fp, TArgs...>(std::forward<Fp>(f), std::forward<TArgs>(args)...);
-        }
-    }
-
-    template<typename Fp, typename... TArgs>
-    requires(std::is_invocable_v<Fp, TArgs...>)
-    inline std::future<std::invoke_result_t<Fp, TArgs...>> il2cpp_async(std::launch policy, Fp&& f, TArgs&&... args) {
-        return std::async<decltype(&il2cpp_async_internal<Fp, TArgs...>), Fp, TArgs...>(policy, &il2cpp_async_internal<Fp, TArgs...>, std::forward<Fp>(f), std::forward<TArgs>(args)...);
-    }
-
-    template<typename Fp, typename... TArgs>
-    requires(std::is_invocable_v<Fp, TArgs...>)
-    inline std::future<std::invoke_result_t<Fp, TArgs...>> il2cpp_async(Fp&& f, TArgs&&... args) {
-        return std::async<decltype(&il2cpp_async_internal<Fp, TArgs...>), Fp, TArgs...>(std::launch::any, &il2cpp_async_internal<Fp, TArgs...>, std::forward<Fp>(f), std::forward<TArgs>(args)...);
+    template<typename Func, typename... TArgs>
+    requires(std::is_invocable_v<Func, TArgs...>)
+    inline std::future<std::invoke_result_t<Func, TArgs...>> il2cpp_async(Func&& f, TArgs&&... args) {
+        auto func = &il2cpp_utils::threading::il2cpp_async_internal<Func, TArgs...>;
+        return std::async<decltype(func), Func, TArgs...>(std::launch::any, std::move(func), std::forward<Func>(f), std::forward<TArgs>(args)...);
     }
 }
 

--- a/src/tests/thread-tests.cpp
+++ b/src/tests/thread-tests.cpp
@@ -112,6 +112,35 @@ void ThreadTest::test_thread() {
     IL2CPP_THREAD_TEST(&ThreadTest::method_rvalue, this, 10);
 }
 
+
+// #define IL2CPP_ASYNC_TEST(...) \
+//     il2cpp_utils::il2cpp_async(__VA_ARGS__).wait(); \
+//     std::async(__VA_ARGS__).wait()
+
+#define IL2CPP_ASYNC_TEST(...) \
+    il2cpp_utils::il2cpp_async(__VA_ARGS__).wait(); \
+    std::async(__VA_ARGS__).wait()
+
+static void func() {}
+static bool func2(int v) { return v; }
+static int* func3(int& v) { return &v; }
+static float func4(int&& v) { return v; }
+
+void test_async() {
+    IL2CPP_ASYNC_TEST([]{ return 1; });
+    IL2CPP_ASYNC_TEST([]{ return 1; });
+    float v = 0;
+    // not allowed on std::async
+    // IL2CPP_ASYNC_TEST([](float& v){ return v + 1; }, v);
+    IL2CPP_ASYNC_TEST(&func);
+    IL2CPP_ASYNC_TEST(&func2, 2);
+    int a = 2;
+    // not allowed on std::async
+    // IL2CPP_ASYNC_TEST(&func3, a);
+    IL2CPP_ASYNC_TEST(&func4, std::move(a));
+    IL2CPP_ASYNC_TEST(&func4, 1);
+    IL2CPP_ASYNC_TEST([&v](int b){ return v = b; }, 1);
+}
 #pragma clang diagnostic pop
 
 #endif

--- a/src/tests/thread-tests.cpp
+++ b/src/tests/thread-tests.cpp
@@ -25,8 +25,8 @@ struct ThreadTest {
 
 // test both il2cpp aware thread and std::thread for equivalence
 #define IL2CPP_THREAD_TEST(...) \
-    il2cpp_utils::il2cpp_aware_thread(__VA_ARGS__).join(); \
-    std::thread(__VA_ARGS__).join()
+    std::thread(__VA_ARGS__).join(); \
+    il2cpp_utils::il2cpp_aware_thread(__VA_ARGS__).join()
 
 void test_thread() {
     // can we make a 0 arg lambda thread?
@@ -76,10 +76,10 @@ void test_thread() {
 
     il2cpp_utils::il2cpp_aware_thread([]{
         // getting current jni env since we are attached
-        auto env = il2cpp_utils::il2cpp_aware_thread::get_current_env();
+        auto env = il2cpp_utils::threading::get_current_env();
 
         // getting current thread id as a test
-        auto id = il2cpp_utils::il2cpp_aware_thread::current_thread_id();
+        auto id = il2cpp_utils::threading::current_thread_id();
     }).join();
 }
 


### PR DESCRIPTION
 - Allow a similiar api to std::async for queueing methods up for an std::future delivery, while wrapping a thread that could be created in a method that registers the thread
 - Reworks il2cpp_aware_thread internals so il2cpp_utils::il2cpp_async can share code