### PR TITLE
Fix SafePtr

### DIFF
--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -96,8 +96,11 @@ struct CountPointer {
             Counter::add(ptr);
         }
     }
-    /// @brief Move constructor is default, moves the pointer and keeps the reference count the same.
-    CountPointer(CountPointer&& other) = default;
+    /// @brief Move constructor moves the pointer and keeps the reference count the same.
+    CountPointer(CountPointer&& other) {
+        ptr = other.ptr;
+        other.ptr = nullptr;
+    }
     /// @brief Destructor, decreases the ref count for the held non-null pointer.
     ~CountPointer() {
         if (ptr) {

--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -270,8 +270,14 @@ struct SafePtr {
     /// @brief Destructor. Destroys the internal wrapper type, if necessary.
     /// Aborts if a wrapper type exists and must be freed, yet GC_free does not exist.
     ~SafePtr() {
+        clear();
+    }
+
+    /// @brief Destroys the internal wrapper type, if necessary.
+    /// Aborts if a wrapper type exists and must be freed, yet GC_free does not exist.
+    inline void clear() {
         if (!internalHandle) {
-            // Destructor without an internal handle is trivial
+            // Clearing up without an internal handle is trivial
             return;
         }
         // If our internal handle has 1 instance, we need to clean up the instance it points to.
@@ -287,19 +293,22 @@ struct SafePtr {
             il2cpp_functions::GC_free(internalHandle.__internal_get());
             #endif
         }
+
+        // ensure we don't try to clear the same handle twice
+        internalHandle = nullptr;
     }
 
     /// @brief Emplace a new value into this SafePtr, freeing an existing one, if it exists.
     /// @param other The instance to emplace.
     inline void emplace(T& other) {
-        this->~SafePtr();
+        clear();
         internalHandle = SafePointerWrapper::New(std::addressof(other));
     }
 
     /// @brief Emplace a new value into this SafePtr, freeing an existing one, if it exists.
     /// @param other The instance to emplace.
     inline void emplace(T* other) {
-        this->~SafePtr();
+        clear();
         internalHandle = SafePointerWrapper::New(other);
     }
 
@@ -307,7 +316,7 @@ struct SafePtr {
     /// @param other The CountPointer to copy during the emplace.
     inline void emplace(CountPointer<T>& other) {
         // Clear existing instance as necessary
-        this->~SafePtr();
+        clear();
         // Copy other into handle
         internalHandle = other;
     }
@@ -316,7 +325,7 @@ struct SafePtr {
     /// @param other The CountPointer to move during this call.
     inline void move(CountPointer<T>& other) {
         // Clear existing instance as necessary
-        this->~SafePtr();
+        clear();
         // Move into handle
         internalHandle = std::move(other);
     }


### PR DESCRIPTION
This PR fixes two problems with SafePtr:

- The move constructor of `CountPointer` would not clear out the ptr in the source instance, leaving both instances with pointers that would be possible to decrease (for example due to deconstruction of the now "empty" instance).
- `SafePtr` would use the destructor to clear out old instances before emplacing or moving, however the destructor would implicitly also destruct the internal `CountPointer`, leading to a decrease of the `CountPointer`. However the `CountPointer` instance would still be "valid", so whenever it's stored pointer would be updated it would decrease again, leading to a double decrease and possible a double free.