### PR TITLE
Adjust const usage of SafePtr::ptr

### DIFF
--- a/shared/utils/typedefs-wrappers.hpp
+++ b/shared/utils/typedefs-wrappers.hpp
@@ -406,7 +406,7 @@ struct SafePtr {
         __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
     }
 
-    T const* ptr() const {
+    T* const ptr() const {
         __SAFE_PTR_NULL_HANDLE_CHECK(internalHandle, internalHandle->instancePointer);
     }
 
@@ -422,19 +422,19 @@ struct SafePtr {
         return *ptr();
     }
 
-    [[nodiscard]] const T& operator*() const {
+    [[nodiscard]] T& operator*() const {
         return *ptr();
     }
 
     [[nodiscard]] T* const operator->() const {
-        return const_cast<T*>(ptr());
+        return ptr();
     }
 
     /// @brief Explicitly cast this instance to a T*.
     /// Note, however, that the lifetime of this returned T* is not longer than the lifetime of this instance.
     /// Consider passing a SafePtr reference or copy instead.
     [[nodiscard]] explicit operator T* const() const {
-        return const_cast<T*>(ptr());
+        return ptr();
     }
 
    private:
@@ -505,7 +505,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
         __SAFE_PTR_UNITY_NULL_HANDLE_CHECK(Parent::internalHandle->instancePointer);
     }
 
-    T const* ptr() const {
+    T* const ptr() const {
         __SAFE_PTR_UNITY_NULL_HANDLE_CHECK(Parent::internalHandle->instancePointer);
     }
 
@@ -523,11 +523,11 @@ struct SafePtrUnity : public SafePtr<T, true> {
     /// Note, however, that the lifetime of this returned T* is not longer than the lifetime of this instance.
     /// Consider passing a SafePtrUnity reference or copy instead.
     explicit operator T* const() const {
-        return const_cast<T*>(ptr());
+        return ptr();
     }
 
     T* const operator->() {
-        return const_cast<T*>(ptr());
+        return ptr();
     }
 
     T* const operator->() const {
@@ -538,7 +538,7 @@ struct SafePtrUnity : public SafePtr<T, true> {
         return *ptr();
     }
 
-    T const& operator*() const {
+    T& operator*() const {
         return *ptr();
     }
 


### PR DESCRIPTION
Adjusts the constness of the const variant of SafePtr::ptr to output a const pointer to `T` instead of a pointer to a const `T`, to bring it in line with the corresponding pointer.

Also remove the constness of the output of `operator*`, since again, the stored object is not constant, the pointer is.