### PR TITLE
Add -Wno-extra-qualification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 # compile options used
 add_compile_options(-frtti -fPIE -fPIC -fexceptions -flto)
 add_link_options(-Wl,--exclude-libs,ALL)
-add_compile_options(-Wall -Wextra -Werror -Wno-unused-function)
+add_compile_options(-Wall -Wextra -Werror -Wno-unused-function -Wno-extra-qualification)
 # clangd bug https://github.com/clangd/clangd/issues/1167
 add_compile_options(-Wno-pragma-pack)
 add_compile_options(-Wno-vla-cxx-extension)

--- a/qpm.json
+++ b/qpm.json
@@ -12,7 +12,10 @@
       "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/debug_libbeatsaber-hook.so",
       "overrideSoName": "libbeatsaber-hook.so",
       "branchName": "master",
-      "cmake": true
+      "cmake": true,
+      "compileOptions": {
+        "cppFlags": ["-Wno-extra-qualification"]
+      }
     }
   },
   "workspace": {

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/QuestPackageManager/QPM.Package/refs/heads/main/qpm.shared.schema.json",
   "config": {
     "version": "0.1.0",
     "sharedDir": "shared",
@@ -13,6 +14,11 @@
         "debugSoLink": "https://github.com/QuestPackageManager/beatsaber-hook/releases/download/v5.0.0/debug_libbeatsaber-hook.so",
         "overrideSoName": "libbeatsaber-hook.so",
         "branchName": "master",
+        "compileOptions": {
+          "cppFlags": [
+            "-Wno-extra-qualification"
+          ]
+        },
         "cmake": true
       }
     },


### PR DESCRIPTION
Recent ndk changes have added warnings which directly cause issues with bshook's type check structs