### PR TITLE
fix: public api exposed capstone

### DIFF
--- a/shared/utils/hooking.hpp
+++ b/shared/utils/hooking.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "flamingo/shared/installer.hpp"
 #include "flamingo/shared/hook-data.hpp"
 #include "flamingo/shared/hook-metadata.hpp"
 #include <type_traits>
@@ -8,7 +9,6 @@
 #include "typedefs.h"
 #include "logging.hpp"
 #include "il2cpp-utils.hpp"
-#include "./capstone-utils.hpp"
 
 namespace Hooking {
 // For use in MAKE_HOOK_AUTO bodies.


### PR DESCRIPTION
currently unnecessarily requires mods to either edit header manually or depend on capstone as capstone utils is not used in hooking.hpp