### PR TITLE
Flamingo hooks 2

### DIFF
--- a/shared/flamingo-utils.hpp
+++ b/shared/flamingo-utils.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <expected>
+#include <iterator>
+#include <optional>
+#include <string_view>
+#include <variant>
+
+#include "config.hpp"
+#include "flamingo/shared/hook-data.hpp"
+#include "flamingo/shared/hook-installation-result.hpp"
+#include "flamingo/shared/installer.hpp"
+#include "flamingo/shared/target-data.hpp"
+#include "scotland2/shared/modloader.h"
+
+#include "utils.hpp"
+
+namespace bs_hook {
+struct FlamingoHandle;
+
+/// @brief Fluent builder for constructing and (re)installing a Flamingo hook with a given priority.
+struct FlamingoHandleBuilder {
+    Paper::LoggerContext logger;
+    flamingo::HookInfo hookInfo;
+
+    FlamingoHandleBuilder(Paper::LoggerContext const& log, flamingo::HookInfo info) : logger(log), hookInfo(std::move(info)) {
+        hookInfo.metadata.priority.is_final = false;
+    }
+    FlamingoHandleBuilder(FlamingoHandleBuilder const&) = default;
+    FlamingoHandleBuilder(FlamingoHandleBuilder&&) = default;
+    ~FlamingoHandleBuilder() = default;
+
+    FlamingoHandleBuilder& operator=(FlamingoHandleBuilder const&) = default;
+    FlamingoHandleBuilder& operator=(FlamingoHandleBuilder&&) = default;
+
+    FlamingoHandleBuilder& final(bool isFinal = true) {
+        hookInfo.metadata.priority.is_final = isFinal;
+        return *this;
+    }
+
+    FlamingoHandleBuilder& after(modloader::ModInfo const& info, std::string_view name = {}) {
+        after(info.id, name);
+        return *this;
+    }
+
+    FlamingoHandleBuilder& after(std::string_view modID, std::string_view name = {}) {
+        hookInfo.metadata.priority.afters.emplace_back(flamingo::HookNameMetadata{
+            .name = std::string(name),
+            .namespaze = std::string(modID),
+        });
+
+        return *this;
+    }
+
+    FlamingoHandleBuilder& before(modloader::ModInfo const& info, std::string_view name = {}) {
+        before(info.id, name);
+        return *this;
+    }
+
+    FlamingoHandleBuilder& before(std::string_view modID, std::string_view name = {}) {
+        hookInfo.metadata.priority.befores.emplace_back(flamingo::HookNameMetadata{ .name = std::string(name), .namespaze = std::string(modID) });
+        return *this;
+    }
+
+    [[nodiscard]]
+    std::expected<FlamingoHandle, flamingo::installation::Error> installOrError() noexcept;
+
+    [[nodiscard]]
+    FlamingoHandle install();
+};
+
+/// @brief A handle to an installed Flamingo hook, allowing for uninstalling and reinstalling with a new priority.
+struct FlamingoHandle {
+    Paper::LoggerContext logger;
+    flamingo::HookInfo info;
+    flamingo::HookHandle handle;
+
+    FlamingoHandle(Paper::LoggerContext logger, flamingo::HookHandle h, flamingo::HookInfo i) : logger(logger), info(i), handle(h) {}
+
+    FlamingoHandle(FlamingoHandle const&) = delete;
+    FlamingoHandle(FlamingoHandle&&) = default;
+
+    FlamingoHandle& operator=(FlamingoHandle const&) = delete;
+    FlamingoHandle& operator=(FlamingoHandle&&) = default;
+
+    ~FlamingoHandle() = default;
+
+    operator flamingo::HookHandle() const {
+        return handle;
+    }
+
+    [[nodiscard]]
+    flamingo::HookHandle const& get_handle() const {
+        return handle;
+    }
+
+    /// @brief Uninstalls the hook associated with this handle.
+    [[nodiscard]]
+    std::expected<FlamingoHandleBuilder, std::monostate> uninstall() {
+        auto result = flamingo::Uninstall(handle);
+        if (result.has_value()) {
+            return FlamingoHandleBuilder(logger, info);
+        }
+        return std::unexpected(std::monostate{});
+    }
+
+    [[nodiscard]]
+    auto reinstall() {
+        auto result = flamingo::Reinstall({ handle.hook_location->target });
+        return result;
+    }
+};
+
+inline std::expected<FlamingoHandle, flamingo::installation::Error> FlamingoHandleBuilder::installOrError() noexcept {
+    logger.info("Installing hook: {} to offset: {}", hookInfo.metadata.name_info, fmt::ptr(hookInfo.target));
+    // Install() takes ownership of hookInfo, so keep a copy around to populate the returned handle's metadata.
+    auto info_copy = hookInfo;
+    auto install_result = flamingo::Install(std::move(hookInfo));
+    if (install_result.has_value()) {
+        return FlamingoHandle(logger, install_result.value().returned_handle, std::move(info_copy));
+    } else {
+        return std::unexpected(install_result.error());
+    }
+}
+
+inline FlamingoHandle FlamingoHandleBuilder::install() {
+    auto result = installOrError();
+    if (!result.has_value()) {
+        logger.critical("Failed to install hook: {} with flamingo: {}", hookInfo.metadata.name_info, result.error());
+        SAFE_ABORT();
+    }
+
+    return std::move(result.value());
+}
+}  // namespace bs_hook

--- a/shared/flamingo-utils.hpp
+++ b/shared/flamingo-utils.hpp
@@ -51,10 +51,10 @@ struct FlamingoHandleBuilder {
     /// @param namespaze The namespace to match; unset matches any namespace.
     /// @param name The hook name to match; unset matches any name.
     FlamingoHandleBuilder& after(std::optional<std::string> namespaze, std::optional<std::string> name = {}) {
-        hookInfo.metadata.priority.afters.emplace_back(flamingo::HookNameFilter{
-            .namespaze = std::move(namespaze),
-            .name = std::move(name),
-        });
+        flamingo::HookNameFilter filter;
+        filter.namespaze = std::move(namespaze);
+        filter.name = std::move(name);
+        hookInfo.metadata.priority.afters.emplace_back(std::move(filter));
 
         return *this;
     }
@@ -71,10 +71,11 @@ struct FlamingoHandleBuilder {
     /// @param namespaze The namespace to match; unset matches any namespace.
     /// @param name The hook name to match; unset matches any name.
     FlamingoHandleBuilder& before(std::optional<std::string> namespaze, std::optional<std::string> name = {}) {
-        hookInfo.metadata.priority.befores.emplace_back(flamingo::HookNameFilter{
-            .namespaze = std::move(namespaze),
-            .name = std::move(name),
-        });
+        flamingo::HookNameFilter filter;
+        filter.namespaze = std::move(namespaze);
+        filter.name = std::move(name);
+        hookInfo.metadata.priority.befores.emplace_back(std::move(filter));
+
         return *this;
     }
 

--- a/shared/flamingo-utils.hpp
+++ b/shared/flamingo-utils.hpp
@@ -113,11 +113,11 @@ struct FlamingoHandle {
 
 inline std::expected<FlamingoHandle, flamingo::installation::Error> FlamingoHandleBuilder::installOrError() noexcept {
     logger.info("Installing hook: {} to offset: {}", hookInfo.metadata.name_info, fmt::ptr(hookInfo.target));
-    // Install() takes ownership of hookInfo, so keep a copy around to populate the returned handle's metadata.
-    auto info_copy = hookInfo;
     auto install_result = flamingo::Install(std::move(hookInfo));
     if (install_result.has_value()) {
-        return FlamingoHandle(logger, install_result.value().returned_handle, std::move(info_copy));
+        // hookInfo was moved, we grab it in the new location
+        auto newHookInfo = *install_result.value().returned_handle.hook_location;
+        return FlamingoHandle(logger, install_result.value().returned_handle, newHookInfo);
     } else {
         return std::unexpected(install_result.error());
     }

--- a/shared/flamingo-utils.hpp
+++ b/shared/flamingo-utils.hpp
@@ -72,10 +72,9 @@ struct FlamingoHandleBuilder {
 /// @brief A handle to an installed Flamingo hook, allowing for uninstalling and reinstalling with a new priority.
 struct FlamingoHandle {
     Paper::LoggerContext logger;
-    flamingo::HookInfo info;
     flamingo::HookHandle handle;
 
-    FlamingoHandle(Paper::LoggerContext logger, flamingo::HookHandle h, flamingo::HookInfo i) : logger(logger), info(i), handle(h) {}
+    FlamingoHandle(Paper::LoggerContext logger, flamingo::HookHandle h) : logger(logger),  handle(h) {}
 
     FlamingoHandle(FlamingoHandle const&) = delete;
     FlamingoHandle(FlamingoHandle&&) = default;
@@ -95,8 +94,9 @@ struct FlamingoHandle {
     }
 
     /// @brief Uninstalls the hook associated with this handle.
-    [[nodiscard]]
-    std::expected<FlamingoHandleBuilder, std::monostate> uninstall() {
+    [[nodiscard]] std::expected<FlamingoHandleBuilder, std::monostate> uninstall() {
+        // grab the hook info and copy it before uninstalling
+        auto info = *handle.hook_location;
         auto result = flamingo::Uninstall(handle);
         if (result.has_value()) {
             return FlamingoHandleBuilder(logger, info);
@@ -115,9 +115,7 @@ inline std::expected<FlamingoHandle, flamingo::installation::Error> FlamingoHand
     logger.info("Installing hook: {} to offset: {}", hookInfo.metadata.name_info, fmt::ptr(hookInfo.target));
     auto install_result = flamingo::Install(std::move(hookInfo));
     if (install_result.has_value()) {
-        // hookInfo was moved, we grab it in the new location
-        auto newHookInfo = *install_result.value().returned_handle.hook_location;
-        return FlamingoHandle(logger, install_result.value().returned_handle, newHookInfo);
+        return FlamingoHandle(logger, install_result.value().returned_handle);
     } else {
         return std::unexpected(install_result.error());
     }

--- a/shared/flamingo-utils.hpp
+++ b/shared/flamingo-utils.hpp
@@ -33,38 +33,56 @@ struct FlamingoHandleBuilder {
     FlamingoHandleBuilder& operator=(FlamingoHandleBuilder const&) = default;
     FlamingoHandleBuilder& operator=(FlamingoHandleBuilder&&) = default;
 
+    /// @brief Marks this hook as final, meaning no other hooks may be installed after it.
     FlamingoHandleBuilder& final(bool isFinal = true) {
         hookInfo.metadata.priority.is_final = isFinal;
         return *this;
     }
 
-    FlamingoHandleBuilder& after(modloader::ModInfo const& info, std::string_view name = {}) {
-        after(info.id, name);
+    /// @brief Requires this hook to be installed after the given mod's hook.
+    /// @param info The mod whose hook this one must be installed after.
+    /// @param name Restricts the match to a specific hook name within that mod; unset matches any hook in the mod's namespace.
+    FlamingoHandleBuilder& after(modloader::ModInfo const& info, std::optional<std::string> name = {}) {
+        after(info.id, std::move(name));
         return *this;
     }
 
-    FlamingoHandleBuilder& after(std::string_view modID, std::string_view name = {}) {
-        hookInfo.metadata.priority.afters.emplace_back(flamingo::HookNameMetadata{
-            .name = std::string(name),
-            .namespaze = std::string(modID),
+    /// @brief Requires this hook to be installed after the hook identified by namespace/name.
+    /// @param namespaze The namespace to match; unset matches any namespace.
+    /// @param name The hook name to match; unset matches any name.
+    FlamingoHandleBuilder& after(std::optional<std::string> namespaze, std::optional<std::string> name = {}) {
+        hookInfo.metadata.priority.afters.emplace_back(flamingo::HookNameFilter{
+            .namespaze = std::move(namespaze),
+            .name = std::move(name),
         });
 
         return *this;
     }
 
-    FlamingoHandleBuilder& before(modloader::ModInfo const& info, std::string_view name = {}) {
-        before(info.id, name);
+    /// @brief Requires this hook to be installed before the given mod's hook.
+    /// @param info The mod whose hook this one must be installed before.
+    /// @param name Restricts the match to a specific hook name within that mod; unset matches any hook in the mod's namespace.
+    FlamingoHandleBuilder& before(modloader::ModInfo const& info, std::optional<std::string> name = {}) {
+        before(info.id, std::move(name));
         return *this;
     }
 
-    FlamingoHandleBuilder& before(std::string_view modID, std::string_view name = {}) {
-        hookInfo.metadata.priority.befores.emplace_back(flamingo::HookNameMetadata{ .name = std::string(name), .namespaze = std::string(modID) });
+    /// @brief Requires this hook to be installed before the hook identified by namespace/name.
+    /// @param namespaze The namespace to match; unset matches any namespace.
+    /// @param name The hook name to match; unset matches any name.
+    FlamingoHandleBuilder& before(std::optional<std::string> namespaze, std::optional<std::string> name = {}) {
+        hookInfo.metadata.priority.befores.emplace_back(flamingo::HookNameFilter{
+            .namespaze = std::move(namespaze),
+            .name = std::move(name),
+        });
         return *this;
     }
 
+    /// @brief Installs the hook, returning an error instead of aborting on failure.
     [[nodiscard]]
     std::expected<FlamingoHandle, flamingo::installation::Error> installOrError() noexcept;
 
+    /// @brief Installs the hook, aborting the process on failure.
     [[nodiscard]]
     FlamingoHandle install();
 };
@@ -84,10 +102,12 @@ struct FlamingoHandle {
 
     ~FlamingoHandle() = default;
 
+    /// @brief Implicit conversion to the underlying Flamingo hook handle.
     operator flamingo::HookHandle() const {
         return handle;
     }
 
+    /// @brief Returns the underlying Flamingo hook handle.
     [[nodiscard]]
     flamingo::HookHandle const& get_handle() const {
         return handle;
@@ -104,6 +124,7 @@ struct FlamingoHandle {
         return std::unexpected(std::monostate{});
     }
 
+    /// @brief Reinstalls the hook at its current target, keeping its existing priority.
     [[nodiscard]]
     auto reinstall() {
         auto result = flamingo::Reinstall({ handle.hook_location->target });

--- a/shared/hooking2.hpp
+++ b/shared/hooking2.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "flamingo-utils.hpp"
+#include "hooking.hpp"
+#include "scotland2/shared/modloader.h"
+
+namespace i2c {
+    namespace detail {
+        // Unlike detail::hook_struct, a flamingo_hook_struct does not carry an install_priority of its own: priority
+        // is set per-install via the FlamingoHandleBuilder's fluent methods instead, since the same hook may be
+        // installed and uninstalled multiple times independently, each with its own priority. It still has an
+        // install_handle slot available, so a caller may optionally store the resulting handle on T itself.
+        template <typename T>
+        concept flamingo_hook_struct =
+            requires {
+                // Must have a name
+                { T::name() } -> std::same_as<char const*>;
+                // Must have a trampoline that returns the func_t
+                { T::trampoline() } -> std::same_as<typename T::func_t*>;
+                // Must have a hook that returns the func_t
+                { T::hook() } -> std::same_as<typename T::func_t>;
+                // Must have an installation handle
+                { T::install_handle } -> std::same_as<flamingo::HookHandle&>;
+            } &&
+            (
+                // Must have an address
+                requires {
+                    { T::addr() } -> std::same_as<void*>;
+                } ||
+                requires {
+                    { T::addr() } -> std::same_as<MethodInfo const*>;
+                }
+            );
+    }
+
+    // Builds a Flamingo hook builder for the provided hook type, resolving its address (or using the one provided),
+    // for installation to a specific mod namespace with an optional priority (before/after/final) attached via the
+    // builder's fluent methods. The resulting handle is not tracked on T, so the same hook may be installed and
+    // uninstalled multiple times independently, each with its own priority.
+    template <detail::flamingo_hook_struct T>
+    bs_hook::FlamingoHandleBuilder make_flamingo_hook(Paper::LoggerContext const& logger, std::string_view namespaze, void* addr = nullptr) {
+        if (!addr) {
+            auto info_or_addr = T::addr();
+            if constexpr (std::is_same_v<decltype(info_or_addr), void*>) {
+                addr = info_or_addr;
+            } else if (info_or_addr) {
+                addr = reinterpret_cast<void*>(info_or_addr->methodPointer);
+            } else {
+                MACRO_LOG(logger, critical, "Attempting to make flamingo hook: {}, but method could not be found!", T::name());
+                SAFE_ABORT("Failure making flamingo hook: {}", T::name());
+            }
+        }
+        if (!addr) {
+            MACRO_LOG(logger, critical, "Attempting to make flamingo hook: {} to invalid destination!", T::name());
+            SAFE_ABORT("Failure making flamingo hook: {}", T::name());
+        }
+        flamingo::HookInfo hookInfo(
+            reinterpret_cast<void*>(T::hook()), addr, reinterpret_cast<void**>(T::trampoline()),
+            flamingo::HookNameMetadata{ .name = T::name(), .namespaze = std::string(namespaze) }
+        );
+        return bs_hook::FlamingoHandleBuilder(logger, std::move(hookInfo));
+    }
+
+    // modloader::ModInfo overload of make_flamingo_hook, using the mod's ID as the hook namespace.
+    template <detail::flamingo_hook_struct T, typename... TArgs>
+    bs_hook::FlamingoHandleBuilder make_flamingo_hook(Paper::LoggerContext const& logger, modloader::ModInfo const& modInfo, TArgs&&... args) {
+        return make_flamingo_hook<T>(logger, std::string_view(modInfo.id), std::forward<TArgs>(args)...);
+    }
+}
+
+#define __INTERNAL_FLAMINGO_HOOK_STRUCT(name_, addr_, ret_type, ...) \
+    constexpr static const char* name() { return #name_; }          \
+    static auto addr() { return addr_; }                            \
+    static func_t hook() { return hook_m_##name_; }                 \
+    static func_t* trampoline() { return &name_; }                  \
+    static inline flamingo::HookHandle install_handle;               \
+    static ret_type hook_m_##name_(__VA_ARGS__); /* Hook */         \
+    static inline ret_type (*name_)(__VA_ARGS__) = nullptr; /* Orig */
+
+// Defines a hook to a manually found address or il2cpp method, for use with FLAMINGO_HOOK/FLAMINGO_HOOK_DIRECT.
+// addr_info must be in parentheses, and can either be an expression that produces a pointer,
+// or a find_class_info, method name, and boolean flag if an instance method.
+// If given an il2cpp method, it will search for one that matches the given return type and parameters.
+// Unlike MAKE_HOOK, this does not carry an install_priority of its own (see FLAMINGO_HOOK).
+#define MAKE_FLAMINGO_HOOK(name_, addr_info, ret_type, ...)                                                        \
+    struct BS_HOOK_HIDDEN hook_##name_ {                                                                          \
+        using func_t = ret_type (*)(__VA_ARGS__);                                                                 \
+        __INTERNAL_FLAMINGO_HOOK_STRUCT(name_, ::i2c::detail::resolve_addr<func_t>{} addr_info, ret_type, __VA_ARGS__) \
+    };                                                                                                             \
+    ret_type hook_##name_::hook_m_##name_(__VA_ARGS__)
+
+// Defines a hook to a method with metadata provided through i2c::metadata_getter, for use with
+// FLAMINGO_HOOK/FLAMINGO_HOOK_DIRECT. Will automatically cast overloads, check types, and detect static/instance
+// methods, based on the given return type and parameters. Generic methods cannot be hooked with this macro.
+// Unlike MAKE_HOOK_MATCH, this does not carry an install_priority of its own (see FLAMINGO_HOOK).
+#define MAKE_FLAMINGO_HOOK_MATCH(name_, method, ret_type, ...)                                                       \
+    struct BS_HOOK_HIDDEN hook_##name_ {                                                                            \
+        static constexpr auto cast_test = []<typename T>() { return requires { static_cast<T>(method); }; };        \
+        using func_t = ret_type (*)(__VA_ARGS__);                                                                   \
+        using cast_t = ::i2c::detail::method_check<cast_test, func_t>::type;                                       \
+        static_assert(cast_test.operator()<cast_t>(), "Hook method signature does not match!");                     \
+        static_assert(::i2c::detail::match_hookable<static_cast<cast_t>(method)>, "Method cannot be hooked!");      \
+        __INTERNAL_FLAMINGO_HOOK_STRUCT(name_, ::i2c::metadata_getter<static_cast<cast_t>(method)>::method_info(), ret_type, __VA_ARGS__) \
+    };                                                                                                               \
+    ret_type hook_##name_::hook_m_##name_(__VA_ARGS__)
+
+// Builds a FlamingoHandleBuilder for the provided hook, namespaced under the given mod ID (either a modloader::ModInfo
+// or a plain string). Chain .before(...)/.after(...)/.final() and finish with .install() or .installOrError().
+// Name must be from either a MAKE_FLAMINGO_HOOK or MAKE_FLAMINGO_HOOK_MATCH macro.
+#define FLAMINGO_HOOK(logger, namespaze, name) \
+    ::i2c::make_flamingo_hook<hook_##name>(logger, namespaze)
+
+// Same as FLAMINGO_HOOK, but installs to the address provided directly instead of resolving it from the hook.
+// Name must be from either a MAKE_FLAMINGO_HOOK or MAKE_FLAMINGO_HOOK_MATCH macro.
+#define FLAMINGO_HOOK_DIRECT(logger, namespaze, name, addr) \
+    ::i2c::make_flamingo_hook<hook_##name>(logger, namespaze, addr)

--- a/src/tests/hooking2.cpp
+++ b/src/tests/hooking2.cpp
@@ -1,0 +1,47 @@
+#include "hooking2.hpp"
+
+#include "members.hpp"
+#include "tests.hpp"
+
+MAKE_FLAMINGO_HOOK(queue_flamingo_test, ({"System.Collections", "Queue"}, "GetElement", true), void*, void* self, int i) {
+    LOG_OK("Flamingo hook run, self -> {} | item -> {} | orig -> {}", fmt::ptr(self), i, queue_flamingo_test(self, i));
+    return reinterpret_cast<void*>(uintptr_t(15));
+}
+
+TEST(flamingo_priority_hook) {
+    LOG_OK("Starting flamingo priority hook test");
+
+    try {
+        auto queue = i2c::new_ctor({"System.Collections", "Queue"});
+        i2c::run_method(queue, "Enqueue", static_cast<Il2CppObject*>(nullptr));
+
+        modloader::ModInfo other_mod{ "other-mod", "1.0.0", 0 };
+
+        // Install as a namespaced hook with an explicit priority, tracked via a handle rather than on the hook struct.
+        auto handle = FLAMINGO_HOOK(i2c::logger, "bs-hooks-tests", queue_flamingo_test).after(other_mod).final().install();
+        LOG_OK("Flamingo hook installed");
+
+        auto element = i2c::run_method<Il2CppObject*>(queue, "GetElement", 0);
+        LOG_OK("Queue GetElement after flamingo hook install -> {}", fmt::ptr(element));
+
+        // Uninstall, getting back a builder that can be used to reinstall with the same (or a new) priority.
+        auto builder = handle.uninstall().value();
+        LOG_OK("Flamingo hook uninstalled");
+
+        element = i2c::run_method<Il2CppObject*>(queue, "GetElement", 0);
+        LOG_OK("Queue GetElement after flamingo hook uninstall -> {}", fmt::ptr(element));
+
+        handle = builder.before("some-other-mod").install();
+        LOG_OK("Flamingo hook reinstalled");
+
+        element = i2c::run_method<Il2CppObject*>(queue, "GetElement", 0);
+        LOG_OK("Queue GetElement after flamingo hook reinstall -> {}", fmt::ptr(element));
+
+        handle.uninstall().value();
+    } catch (std::exception const& e) {
+        LOG_FAIL("Error during flamingo priority hook test: {}", e.what());
+        return;
+    }
+
+    LOG_OK("Flamingo priority hook test complete");
+}


### PR DESCRIPTION
## Summary

Adds a second, opt-in hook-installation API (`hooking2.hpp`) alongside the existing `hooking.hpp`, for cases where hook priority (before/after/final) needs to be decided **at runtime** rather than baked in at compile time via `HOOK_BEFORE`/`HOOK_AFTER`/`HOOK_ORIG`.

I'm also unsure if this is the best way to do it for all hook instances, which is why I'm keeping the original hook methods as-is.

## Old hooking (`hooking.hpp`)

Priority is fixed at compile time via separate macros, and there's exactly one install/uninstall slot per hook (`T::install_handle`):

```cpp
MAKE_HOOK(my_hook, (klass, "MyMethod", true), void, void* self) {
    my_hook(self);
}

// priority decided once, at compile time
HOOK_AFTER(my_hook, "chroma");
HOOK_BEFORE(my_hook, "camera-plus");

INSTALL_HOOK(logger, my_hook);
// ... later ...
UNINSTALL_HOOK(logger, my_hook);

## New hooking (hooking2.hpp)
Priority is set fluently at install time, and each install returns its own handle. This allows putting the handle in a `vector<FlamingoHandle>` if one wanted to install/uninstall a set of hooks at once.

```cpp
MAKE_FLAMINGO_HOOK(my_hook, (klass, "MyMethod", true), void, void* self) {
    my_hook(self);
}

auto handle = FLAMINGO_HOOK(logger, "my-mod-id", my_hook)
    .after("chroma")
    .before("camera-plus")
    .final()          // optional
    .install();

// ... later ...
auto builder = handle.uninstall().value();  // get back a builder to reinstall
handle = builder.before("some-other-mod").install();
```

### Benefits
- Priority (`.before()`/`.after()`/`.final()`) is chosen per-install, not fixed at compile time - useful when ordering depends on which other mods are loaded.

- A hook can be installed/uninstalled/reinstalled independently multiple times, each with a different priority, without redefining the hook. Though this benefit is not really that useful unless we wanted to provide a UserData parameter too e.g AffinityPatches on PC.

- Hooks are explicitly namespaced under a mod ID (`string` or `modloader::ModInfo`), which Flamingo uses for before/after name resolution across mods.

-Errors surface as `std::expected` (`installOrError()`), so failure handling doesn't require exceptions if you don't want them; `.install()` still aborts on failure like `INSTALL_HOOK` does.

### Caveats
- Separate macro family: hooks meant for FLAMINGO_HOOK must be declared with MAKE_FLAMINGO_HOOK/MAKE_FLAMINGO_HOOK_MATCH, not MAKE_HOOK/MAKE_HOOK_MATCH - the two aren't interchangeable for the same hook name.
- More verbose for the common case (simple always-on hook with no priority needs) - `INSTALL_HOOK` is still the better default there.
- The returned `FlamingoHandle` is move-only and must be held onto by the caller to uninstall/reinstall later; there's no built-in tracking on the hook struct the way `T::install_handle` works for hooking.hpp today

